### PR TITLE
Adding HyLight for hybrid assembly

### DIFF
--- a/config/template_config.yaml
+++ b/config/template_config.yaml
@@ -56,6 +56,10 @@ assembly:
     threads: 4
     memory_limit: 50 # in GB
     min_contig_len: 500 # minimal contig length to be kept in the produced assembly
+  hylight:
+    threads: 4
+    min_contig_len: 500 # minimal contig length to be kept in the produced assembly
+    other_params: "" # other parameters to pass to hylight (e.g. "--nsplit 100")
 
 ################################################################################
 #                               Assembly quality                               #

--- a/workflow/envs/hylight.yaml
+++ b/workflow/envs/hylight.yaml
@@ -1,0 +1,8 @@
+name: hylight
+channels:
+  - bioconda
+  - conda-forge
+dependencies:
+  - hylight=1.0.*
+  - seqtk=r82
+  - pigz=2.*


### PR DESCRIPTION
Added a rule to use HyLight to assembly reads using both short and long reads.

https://doi.org/10.1038/s41467-024-52907-0

Closes #26 